### PR TITLE
Fixed steps order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## [Unreleased]
 
-## [1.0.3]
+## [1.0.2]
 ### Added
 - Nested steps
 - GitHub workflows integration
 ### Changed
 - Upgraded versions: Junit, agent-java, Mockito
 - Moved project to Gradle
+### Fixed
+- Steps order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [1.0.2]
+## [1.0.5]
 ### Added
 - Nested steps
 - GitHub workflows integration

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 name=agent-java-karate
-version=1.0.2
+version=1.0.5
 description=EPAM Report portal. Karate test framework [1.3.1; ) adapter
 gradle_version=8.2
 reportportal_client_java_version=5.1.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 name=agent-java-karate
-version=1.0.3
+version=1.0.2
 description=EPAM Report portal. Karate test framework [1.3.1; ) adapter
 gradle_version=8.2
 reportportal_client_java_version=5.1.16


### PR DESCRIPTION
Workaround was applied ( `ConcurrentHashMap ` for each step item with an `AtomicLong ` representing the last step time ).
Step startTime and endTime will be provided by Karate in v1.4.1 https://github.com/karatelabs/karate/commit/30e93ed95e54d53b81a2a760a61aa1ad220cb55b
Then the agent can be modified to fit the new data provided by Karate.